### PR TITLE
Fix weapon serial duplication

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -36,13 +36,13 @@ RegisterNetEvent('rsg-weapons:server:SaveAmmo', function(serie, ammo, ammoclip)
     local itemData
     for v,k in pairs(Player.PlayerData.items) do
         if k.type == 'weapon' then
-            if ''..k.info.serie..'' == ''..serie..'' then
+            if k.info.serie == serie then
                 svslot = k.slot
                 itemData = Player.Functions.GetItemBySlot(svslot)
                 itemData.info.ammo = ammo
                 itemData.info.ammoclip = ammoclip
-                Player.Functions.RemoveItem(itemData.name, itemData.amount, slot)
-                Player.Functions.AddItem(itemData.name, itemData.amount, slot, itemData.info)
+                Player.Functions.RemoveItem(itemData.name, itemData.amount, svslot)
+                Player.Functions.AddItem(itemData.name, itemData.amount, svslot, itemData.info)
             end
         end
     end


### PR DESCRIPTION
When 2 or more weapons of the same type is available in the inventory _(i.e. 1st weapon in 4th slot, second weapon in 26th slot)_; one of the weapon we use will overwrite the other weapon's serial number because slot numbering didn't get set properly.