### PR TITLE
Handle weapons ammo count

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -3,7 +3,7 @@ Config = {}
 Config.Debug = false
 
 -- settings
-Config.UpdateAmmo = 10000 -- amount of time before saving player ammo in miliseconds
+--Config.UpdateAmmo = 10000 -- amount of time before saving player ammo in miliseconds
 
 -- limit the amount of ammo players can load
 Config.MaxArrowAmmo = 12

--- a/server/server.lua
+++ b/server/server.lua
@@ -36,7 +36,7 @@ end)
 
 -- end of use ammo
 
--- save ammo
+-- save ammo changed by adlan
 RegisterNetEvent('rsg-weapons:server:SaveAmmo', function(serie, ammo, ammoclip)
     local src = source
     local Player = RSGCore.Functions.GetPlayer(src)
@@ -46,14 +46,13 @@ RegisterNetEvent('rsg-weapons:server:SaveAmmo', function(serie, ammo, ammoclip)
         if k.type == 'weapon' then
             if k.info.serie == serie then
                 svslot = k.slot
-                itemData = Player.Functions.GetItemBySlot(svslot)
-                itemData.info.ammo = ammo
-                itemData.info.ammoclip = ammoclip
-                Player.Functions.RemoveItem(itemData.name, itemData.amount, svslot)
-                Player.Functions.AddItem(itemData.name, itemData.amount, svslot, itemData.info)
+
+                Player.PlayerData.items[svslot].info.ammo = ammo
+                Player.PlayerData.items[svslot].info.ammoclip = ammoclip
             end
         end
     end
+    Player.Functions.SetInventory(Player.PlayerData.items)
 end)
 
 -- remove ammo from player


### PR DESCRIPTION
Server
1. Changed from remove/add items to SetInventory method

Client
1. Only update the ammo count during shooting and reload. needn't by interval
2. create a weapon array to handle different serial number
3. ammo will not be removed after death or relog.