### PR TITLE
Small tweaks and changes

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -56,7 +56,7 @@ local getGuidFromItemId = function(inventoryId, itemData, category, slotId)
 end
 
 local addWardrobeInventoryItem = function(itemName, slotHash)
-    local itemHash = GetHashKey(itemName)
+    local itemHash = joaat(itemName)
     local addReason = `ADD_REASON_DEFAULT`
     local inventoryId = 1
     local isValid = Citizen.InvokeNative(0x6D5D51B188333FD1, itemHash, 0)
@@ -97,7 +97,7 @@ end
 -- auto dual-wield
 ------------------------------------------
 RegisterNetEvent('rsg-weapons:client:AutoDualWield', function()
-    local ped = PlayerPedId()
+    local ped = cache.ped
 
     addWardrobeInventoryItem("CLOTHING_ITEM_M_OFFHAND_000_TINT_004", 0xF20B6B4A)
     addWardrobeInventoryItem("UPGRADE_OFFHAND_HOLSTER", 0x39E57B01)
@@ -111,9 +111,9 @@ end)
 -- use weapon
 ------------------------------------------
 RegisterNetEvent('rsg-weapons:client:UseWeapon', function(weaponData, shootbool)
-    local ped = PlayerPedId()
+    local ped = cache.ped
     local weaponName = tostring(weaponData.name)
-    local hash = GetHashKey(weaponData.name)
+    local hash = joaat(weaponData.name)
     local wepSerial = tostring(weaponData.info.serie)
     local wepQuality = weaponData.info.quality
     
@@ -160,56 +160,56 @@ RegisterNetEvent('rsg-weapons:client:UseWeapon', function(weaponData, shootbool)
                     if ammo == 0 then
                         local hasItem = RSGCore.Functions.HasItem('ammo_arrow', 1)
                         if hasItem then
-                            Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_ARROW'), Config.AmountArrowAmmo, 0xCA3454E6)
+                            Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_ARROW`, Config.AmountArrowAmmo, 0xCA3454E6)
                             TriggerServerEvent('rsg-weapons:server:removeWeaponAmmoItem', 'ammo_arrow')
                         else
                             ammo = 0
-                            lib.notify({ title = 'No Arrows', type = 'error', duration = 5000 })
                         end
                     else
-                        Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_ARROW'), ammo, 0xCA3454E6)
+                        Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_ARROW`, ammo, 0xCA3454E6)
                     end
 
                     if ammo_fire == 0 then
                         local hasItem = RSGCore.Functions.HasItem('ammo_arrow_fire', 1)
                         if hasItem then
-                            Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_ARROW_FIRE'), Config.AmountArrowAmmo, 0xCA3454E6)
+                            Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_ARROW_FIRE`, Config.AmountArrowAmmo, 0xCA3454E6)
                             TriggerServerEvent('rsg-weapons:server:removeWeaponAmmoItem', 'ammo_arrow_fire')
                         else
                             ammo_fire = 0
-                            lib.notify({ title = 'No Fire Arrows', type = 'error', duration = 5000 })
                         end
                     else
-                        Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_ARROW_FIRE'), ammo_fire, 0xCA3454E6)
+                        Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_ARROW_FIRE`, ammo_fire, 0xCA3454E6)
                     end
 
                     if ammo_poison == 0 then
                         local hasItem = RSGCore.Functions.HasItem('ammo_arrow_poison', 1)
                         if hasItem then
-                            Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_ARROW_POISON'), Config.AmountArrowAmmo, 0xCA3454E6)
+                            Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_ARROW_POISON`, Config.AmountArrowAmmo, 0xCA3454E6)
                             TriggerServerEvent('rsg-weapons:server:removeWeaponAmmoItem', 'ammo_arrow_poison')
                         else
                             ammo_poison = 0
-                            lib.notify({ title = 'No Poison Arrows', type = 'error', duration = 5000 })
                         end
                     else
-                        Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_ARROW_POISON'), ammo_poison, 0xCA3454E6)
+                        Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_ARROW_POISON`, ammo_poison, 0xCA3454E6)
                     end
 
                     if ammo_dynamite == 0 then
                         local hasItem = RSGCore.Functions.HasItem('ammo_arrow_dynamite', 1)
                         if hasItem then
-                            Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_ARROW_DYNAMITE'), Config.AmountArrowAmmo, 0xCA3454E6)
+                            Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_ARROW_DYNAMITE`, Config.AmountArrowAmmo, 0xCA3454E6)
                             TriggerServerEvent('rsg-weapons:server:removeWeaponAmmoItem', 'ammo_arrow_dynamite')
                         else
                             ammo_dynamite = 0
-                            lib.notify({ title = 'No Dynamite Arrows', type = 'error', duration = 5000 })
                         end
                     else
-                        Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_ARROW_DYNAMITE'), ammo_dynamite, 0xCA3454E6)
+                        Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_ARROW_DYNAMITE`, ammo_dynamite, 0xCA3454E6)
                     end
 
                     Citizen.InvokeNative(0x5E3BDDBCB83F3D84, ped, hash, 0, false, true)
+
+                    if ammo == 0 and ammo_fire == 0 and ammo_poison == 0 and ammo_dynamite == 0 then
+                        lib.notify({ title = 'No Arrows', type = 'error', duration = 5000 })
+                    end
 
                 --check throwables weapons
                 elseif string.find(weaponName, 'thrown') then
@@ -233,45 +233,45 @@ RegisterNetEvent('rsg-weapons:client:UseWeapon', function(weaponData, shootbool)
                 Citizen.InvokeNative(0xDCD2A934D65CB497, ped, hash, 0)
 
                 if string.find(weaponName, 'revolver') then
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REVOLVER'), ammo, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REVOLVER_HIGH_VELOCITY'), ammo_high_velocity, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REVOLVER_SPLIT_POINT'), ammo_split_point, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REVOLVER_EXPRESS'), ammo_express, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REVOLVER_EXPRESS_EXPLOSIVE'), ammo_express_explosive, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REVOLVER`, ammo, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REVOLVER_HIGH_VELOCITY`, ammo_high_velocity, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REVOLVER_SPLIT_POINT`, ammo_split_point, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REVOLVER_EXPRESS`, ammo_express, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REVOLVER_EXPRESS_EXPLOSIVE`, ammo_express_explosive, 0xCA3454E6)
                 end
                 if string.find(weaponName, 'pistol') then
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_PISTOL'), ammo, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_PISTOL_HIGH_VELOCITY'), ammo_high_velocity, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_PISTOL_SPLIT_POINT'), ammo_split_point, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_PISTOL_EXPRESS'), ammo_express, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_PISTOL_EXPRESS_EXPLOSIVE'), ammo_express_explosive, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_PISTOL`, ammo, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_PISTOL_HIGH_VELOCITY`, ammo_high_velocity, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_PISTOL_SPLIT_POINT`, ammo_split_point, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_PISTOL_EXPRESS`, ammo_express, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_PISTOL_EXPRESS_EXPLOSIVE`, ammo_express_explosive, 0xCA3454E6)
                 end
                 if string.find(weaponName, 'repeater') then
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REPEATER'), ammo, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REPEATER_HIGH_VELOCITY'), ammo_high_velocity, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REPEATER_SPLIT_POINT'), ammo_split_point, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REPEATER_EXPRESS'), ammo_express, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_REPEATER_EXPRESS_EXPLOSIVE'), ammo_express_explosive, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REPEATER`, ammo, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REPEATER_HIGH_VELOCITY`, ammo_high_velocity, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REPEATER_SPLIT_POINT`, ammo_split_point, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REPEATER_EXPRESS`, ammo_express, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_REPEATER_EXPRESS_EXPLOSIVE`, ammo_express_explosive, 0xCA3454E6)
                 end
                 if string.find(weaponName, 'rifle') and weaponName ~= 'weapon_rifle_elephant' and weaponName ~= 'weapon_rifle_varmint' then
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_RIFLE'), ammo, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_RIFLE_HIGH_VELOCITY'), ammo_high_velocity, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_RIFLE_SPLIT_POINT'), ammo_split_point, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_RIFLE_EXPRESS'), ammo_express, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_RIFLE_EXPRESS_EXPLOSIVE'), ammo_express_explosive, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_RIFLE`, ammo, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_RIFLE_HIGH_VELOCITY`, ammo_high_velocity, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_RIFLE_SPLIT_POINT`, ammo_split_point, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_RIFLE_EXPRESS`, ammo_express, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_RIFLE_EXPRESS_EXPLOSIVE`, ammo_express_explosive, 0xCA3454E6)
                 end
                 if string.find(weaponName, 'shotgun') then
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_SHOTGUN'), ammo, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_SHOTGUN_BUCKSHOT_INCENDIARY'), ammo_buckshot_incendiary, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_SHOTGUN_SLUG'), ammo_slug, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_SHOTGUN_SLUG_EXPLOSIVE'), ammo_slug_explosive, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_SHOTGUN`, ammo, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_SHOTGUN_BUCKSHOT_INCENDIARY`, ammo_buckshot_incendiary, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_SHOTGUN_SLUG`, ammo_slug, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_SHOTGUN_SLUG_EXPLOSIVE`, ammo_slug_explosive, 0xCA3454E6)
                 end
                 if weaponName == 'weapon_rifle_elephant' then
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_RIFLE_ELEPHANT'), ammo, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_RIFLE_ELEPHANT`, ammo, 0xCA3454E6)
                 end
                 if weaponName == 'weapon_rifle_varmint' then
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_22'), ammo, 0xCA3454E6)
-                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, joaat('AMMO_22_TRANQUILIZER'), ammo, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_22`, ammo, 0xCA3454E6)
+                    Citizen.InvokeNative(0x5FD1E1F011E76D7E, ped, `AMMO_22_TRANQUILIZER`, ammo, 0xCA3454E6)
                 end
 
                 if Config.Debug then
@@ -299,7 +299,7 @@ RegisterNetEvent('rsg-weapons:client:UseWeapon', function(weaponData, shootbool)
             end
 
             -- set degradation
-            local object = GetObjectIndexFromEntityIndex(GetCurrentPedWeaponEntityIndex(PlayerPedId(), 0))
+            local object = GetObjectIndexFromEntityIndex(GetCurrentPedWeaponEntityIndex(cache.ped, 0))
             if not DoesEntityExist(object) then return end
             if wepQuality == 100 then
                 Citizen.InvokeNative(0xA7A57E89E965D839, object, 0.0)
@@ -342,7 +342,7 @@ AddEventHandler("rsg-weapon:client:LoadComponents", function(components, hash)
             LoadModel(components[i].model)
         end
 
-        GiveWeaponComponentToEntity(PlayerPedId(), components[i].name, hash, true)
+        GiveWeaponComponentToEntity(cache.ped, components[i].name, hash, true)
 
         if components[i].model ~= 0 then
             SetModelAsNoLongerNeeded(components[i].model)
@@ -356,7 +356,7 @@ end)
 CreateThread(function()
     while true do
         Wait(1)
-        local ped = PlayerPedId()
+        local ped = cache.ped
         if IsPedShooting(ped) then
             local heldWeapon = Citizen.InvokeNative(0x8425C5F057012DAB, ped)
             local currentSerial = weaponInHands[heldWeapon]
@@ -386,7 +386,7 @@ end)
 -- repair weapon
 ------------------------------------------
 RegisterNetEvent('rsg-weapons:client:repairweapon', function()
-    local ped = PlayerPedId()
+    local ped = cache.ped
     local heldWeapon = Citizen.InvokeNative(0x8425C5F057012DAB, ped)
     local currentSerial = weaponInHands[heldWeapon]
     if currentSerial ~= nil and heldWeapon ~= -1569615261 then
@@ -441,7 +441,7 @@ end)
 -- repair broken weapon
 ------------------------------------------
 RegisterNetEvent('rsg-weapons:client:repairbrokenweapon', function(serial)
-    local ped = PlayerPedId()
+    local ped = cache.ped
     local hasItem = RSGCore.Functions.HasItem('weapon_repair_kit', 1)
     if hasItem and serial ~= nil then
         lib.progressBar({


### PR DESCRIPTION
- Replaced calls to PlayerPedId() with a cached variable cache.ped, as it is available upon loading ox_lib.
- Eliminated redundant use of joaat() for hash calculations.
- Modified arrow notifications to provide better feedback. Instead of displaying notifications for every type of arrow, now a notification is triggered only when no arrows are present. This refinement enhances user experience by reducing unnecessary clutter and providing clearer feedback when relevant.