### PR TITLE
weapon item synced degradation fix

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -297,7 +297,7 @@ RegisterNetEvent('rsg-weapons:client:UseWeapon', function(weaponData, shootbool)
             if wepQuality == 100 then
                 Citizen.InvokeNative(0xA7A57E89E965D839, object, 0.0)-- SetWeaponDegradation(
             else
-                local currentDeg = wepQuality / 100
+                local currentDeg = (1.0 - (wepQuality / 100))
                 Citizen.InvokeNative(0xA7A57E89E965D839, object, currentDeg) -- SetWeaponDegradation(
             end
 


### PR DESCRIPTION
Hi guys, I'm debugging the rsg-weapons (commit 1ed1078) code, because of a bug related to the condition of the weapons that was very strange and not synchronized with the quality of the item. I found an error in the use of the degradation native. In the case of the code below, if we take the example of a weapon of quality 98, it will degrade 0.98 (98%) of the weapon, which doesn't make much sense. The fix is very simple, just change it to local currentDeg = (1.0 - (wepQuality / 100)). Maybe it was just an oversight, but it has a big impact on how this feature works